### PR TITLE
load $PATH from dotfiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "react": "^15.4.1",
     "style-loader": "^0.13.1",
     "webpack": "2.1.0-beta.27"
+  },
+  "dependencies": {
+    "fix-path": "2.1.0"
   }
 }

--- a/src/getDefinition.js
+++ b/src/getDefinition.js
@@ -1,6 +1,8 @@
 // Get dict.py source code using webpack file-loader
 const command = require('raw-loader!./dict.py')
 const { memoize, shellCommand } = require('cerebro-tools')
+const fixPath = require('fix-path')
+fixPath()
 
 // Expire definition cache in 30 minutes
 const EXPIRATION = 30 * 60 * 1000


### PR DESCRIPTION
I use macOS Sierra10.12.

according to [DictionaryServices official API doc]:

> Warning On OSX 10.12 the interpreter crashes when using this framework using a python.org binary.

Unfortunately, system default python (`/usr/bin/python`) is a python.org binary.

If you run `/usr/bin/python ./src/dict.py word` you'll get:

```
2017-02-03 15:24:46.584 Python[55564:7657090] Error loading /System/Library/PrivateFrameworks/MobileAsset.framework/MobileAsset:  dlopen(/System/Library/PrivateFrameworks/MobileAsset.framework/MobileAsset, 265): no suitable image found.  Did find:
        /System/Library/PrivateFrameworks/MobileAsset.framework/MobileAsset: mach-o, but wrong architecture
Traceback (most recent call last):
  File "src/dict.py", line 13, in <module>
    main()
  File "src/dict.py", line 10, in main
    print dictresult.encode('utf-8')
AttributeError: 'NoneType' object has no attribute 'encode'
```

while `/usr/local/bin/python ./src/dict.py word` works perfectly. (this `python` is installed via homebrew).

In shell, `$PATH` is properly setup, so `python ./src/dict.py word` works.
And if I run Cerebro source on command line using `npm run dev`, it also works.

But if Cerebro is build into a standalone app, which is not launched from command line, it lost properly configured `$PATH`, and `python ./src/dict.py word` is actually `/usr/bin/python ./src/dict.py word`, which does not work.

This PR use [fix-path](https://github.com/sindresorhus/fix-path), which solves exactly this problem.
